### PR TITLE
2.9.12.67+pgjdbc-ng

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
                  [org.clojure/clojure "1.9.0"]
                  [org.clojure/tools.cli "0.3.7"]
                  [org.clojure/tools.logging "0.4.1"]
-                 [org.postgresql/postgresql "42.2.2"]
+                 [com.impossibl.pgjdbc-ng/pgjdbc-ng "0.6"]
                  [org.webjars.bower/tether "1.4.4"]
                  [org.webjars/bootstrap "4.1.1"]
                  [org.webjars/font-awesome "5.1.0"]

--- a/project.clj
+++ b/project.clj
@@ -50,7 +50,7 @@
    :dev           [:project/dev :profiles/dev]
    :test          [:project/dev :project/test :profiles/test]
 
-   :project/dev  {:jvm-opts ["-Dconf=dev-config.edn" "--add-modules" "java.xml.bind"]
+   :project/dev  {:jvm-opts ["-Dconf=dev-config.edn" #_"--add-modules" #_"java.xml.bind"]
                   :dependencies [[expound "0.7.1"]
                                  [pjstadig/humane-test-output "0.8.3"]
                                  [prone "1.6.0"]

--- a/src/clj/luminusdiff/db/core.clj
+++ b/src/clj/luminusdiff/db/core.clj
@@ -19,20 +19,3 @@
   :stop (conman/disconnect! *db*))
 
 (conman/bind-connection *db* "sql/queries.sql")
-
-
-(extend-type clojure.lang.IPersistentVector
-  jdbc/ISQLParameter
-  (set-parameter [v ^java.sql.PreparedStatement stmt ^long idx]
-    (let [conn      (.getConnection stmt)
-          meta      (.getParameterMetaData stmt)
-          type-name (.getParameterTypeName meta idx)]
-      (if-let [elem-type (when (= (first type-name) \_) (apply str (rest type-name)))]
-        (.setObject stmt idx (.createArrayOf conn elem-type (to-array v)))
-        (.setObject stmt idx (to-pg-json v))))))
-
-(extend-protocol jdbc/ISQLValue
-  IPersistentMap
-  (sql-value [value] (to-pg-json value))
-  IPersistentVector
-  (sql-value [value] (to-pg-json value)))


### PR DESCRIPTION
https://github.com/luminus-framework/luminus-template/issues/281

Is all that was needed for this change remove the incompatible parts of PostgreSQL driver?  

In my own limited experience, I haven't noticed much of a difference between using the +postgres driver and the PGJDBC-NG changes mentioned in @yogthos post https://yogthos.net/posts/2016-11-05-LuminusPostgresNotifications.html

If there's anything else to get this change up to completion, let me know, thanks. 
